### PR TITLE
feat: associate players with users during creation

### DIFF
--- a/leetarena/leetarena/src/main/java/com/example/leetarena/controllers/PlayerController.java
+++ b/leetarena/leetarena/src/main/java/com/example/leetarena/controllers/PlayerController.java
@@ -42,6 +42,15 @@ public class PlayerController {
         }
     }
 
+    @GetMapping("/byuser/{userId}")
+    public ResponseEntity<List<Player>> getPlayersByUserId(@PathVariable Integer userId) {
+        try {
+            return ResponseEntity.ok(playerService.getPlayersByUserId(userId));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @PostMapping("/create")
     public ResponseEntity<Player> createPlayer(@RequestBody PlayerDTO dto) {
         try {
@@ -61,7 +70,7 @@ public class PlayerController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Integer id) {
+    public ResponseEntity<Void> deletePlayer(@PathVariable Integer id) {
         try {
             playerService.deletePlayer(id);
             return ResponseEntity.noContent().build();

--- a/leetarena/leetarena/src/main/java/com/example/leetarena/dtos/PlayerDTO.java
+++ b/leetarena/leetarena/src/main/java/com/example/leetarena/dtos/PlayerDTO.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class PlayerDTO {
     private String playerUsername;
+    private Integer userId;
 }

--- a/leetarena/leetarena/src/main/java/com/example/leetarena/services/PlayerService.java
+++ b/leetarena/leetarena/src/main/java/com/example/leetarena/services/PlayerService.java
@@ -1,11 +1,12 @@
 package com.example.leetarena.services;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.leetarena.dtos.PlayerDTO;
 import com.example.leetarena.models.Player;
+import com.example.leetarena.models.User;
 import com.example.leetarena.repositories.PlayerRepository;
+import com.example.leetarena.repositories.UserRepository;
 
 import java.util.List;
 
@@ -13,10 +14,11 @@ import java.util.List;
 public class PlayerService {
     
     private final PlayerRepository playerRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    public PlayerService(PlayerRepository playerRepository) {
+    public PlayerService(PlayerRepository playerRepository, UserRepository userRepository) {
         this.playerRepository = playerRepository;
+        this.userRepository = userRepository;
     }
 
     public List<Player> getAllPlayers(){
@@ -28,13 +30,21 @@ public class PlayerService {
             .orElseThrow(() -> new RuntimeException("Player not found"));
     }
 
-    public Player createPlayer(PlayerDTO dto){
-        Player newPlayer = new Player();
+    public List<Player> getPlayersByUserId(Integer userId) {
+        return playerRepository.getPlayersByUserId(userId);
+    }
 
+    public Player createPlayer(PlayerDTO dto){
+        // Find the user by userId
+        User user = userRepository.findById(dto.getUserId())
+            .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        Player newPlayer = new Player();
         newPlayer.setPlayerUsername(dto.getPlayerUsername());
         newPlayer.setPlayerEasys((byte) 0);
         newPlayer.setPlayerMediums((byte) 0);
         newPlayer.setPlayerHards((byte) 0);
+        newPlayer.setUser(user); // Associate player with user
 
         return playerRepository.save(newPlayer);
     }
@@ -54,6 +64,5 @@ public class PlayerService {
 
     public void deletePlayer(Integer id){
        playerRepository.deleteById(id);
-        // TODO: message if user is deleted correctly
     }
 }


### PR DESCRIPTION
- Add userId field to PlayerDTO to specify which user the player belongs to
- Update PlayerService to include UserRepository dependency
- Modify createPlayer() method to find user by userId and associate player with user
- Add getPlayersByUserId() method to retrieve all players for a specific user
- Add new endpoint GET /players/byuser/{userId} to get players by user ID
- Fix method name in PlayerController delete endpoint (deleteUser -> deletePlayer)
- Ensure proper error handling when user is not found during player creation

This ensures that every player is properly associated with a user, maintaining data integrity and enabling user-specific player management.